### PR TITLE
Upgrade branch 2.6.x using TemplateControl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 sbtPlugin := true
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.2"
 
 scriptedSettings
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -5,10 +5,10 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "$scala_version$"
+scalaVersion := "2.12.2"
 
 libraryDependencies += guice
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "$scalatestplusplay_version$" % Test
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.0.0-M3" % Test
 
 // Adds additional packages into Twirl
 //TwirlKeys.templateImports += "$organization$.controllers._"

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "$play_version$")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-M4")


### PR DESCRIPTION
```
Updated with template-control on 2017-04-24T19:53:50.937Z
  /LICENSE:
    wrote /LICENSE
  **/build.sbt:
    scalaVersion := "2.12.2"
  **/build.sbt:
    libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.0.0-M3" % Test
  **/build.sbt:
    scalaVersion := "2.12.2"
  **/plugins.sbt:
    addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-M4")

```
          