### PR TITLE
sbt new does not like stable modifier

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -2,5 +2,5 @@ description = This template generates a Play Scala project
 name = play-scala-seed
 organization=com.example
 verbatim=*.css *.js *.png logback.xml gradle*
-scalatestplusplay_version = maven(org.scalatestplus.play, scalatestplus-play_2.12, stable)
-play_version = maven(com.typesafe.play, play_2.12, stable)
+scalatestplusplay_version = maven(org.scalatestplus.play, scalatestplus-play_2.12)
+play_version = maven(com.typesafe.play, play_2.12)


### PR DESCRIPTION
The stable modifier is defined in http://www.foundweekends.org/giter8/template.html#Maven+properties

If you use g8 file://play-scala-seed.g8 then you get the stable modifier, but using sbt 0.13.15, you get the raw string itself.