### PR TITLE
Upgrade branch 2.6.x using TemplateControl

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,7 +8,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala)
 scalaVersion := "2.12.2"
 
 libraryDependencies += guice
-libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "$scalatestplusplay_version$" % Test
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.0" % Test
 
 // Adds additional packages into Twirl
 //TwirlKeys.templateImports += "$organization$.controllers._"

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,2 +1,2 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")


### PR DESCRIPTION
```
Updated with template-control on 2017-07-07T00:45:58.767Z
  **/build.sbt:
    libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.0" % Test
  **/plugins.sbt:
    addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.1")

```
          