### PR TITLE
Removed unused property name from g8 build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 lazy val root = (project in file(".")).
   settings(
-    name := "My Template Project",
     test in Test := {
       val _ = (g8Test in Test).toTask("").value
     },


### PR DESCRIPTION
Removed unused property name from g8 build.sbt because name property is configured in src/main/g8/default.properties