### PR TITLE
Escape $ in build.gradle

### DIFF
--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     play "com.typesafe.play:play-logback_\$scalaVersion:\$playVersion"
     play "com.typesafe.play:filters-helpers_\$scalaVersion:\$playVersion"
 
-    playTest "org.scalatestplus.play:scalatestplus-play_$scalaVersion:3.1.2"
+    playTest "org.scalatestplus.play:scalatestplus-play_\$scalaVersion:3.1.2"
 }
 
 repositories {


### PR DESCRIPTION
This unescaped `$` is caused failures like the ones described in #74.

I don't know how to write tests for this, since I am new to this repo, but I think something should be done regarding this because this is the second time this is happening. Any ideas?