### PR TITLE
[2.6.x] remove usage of interpolation variables

### DIFF
--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -51,12 +51,17 @@ model {
 //     defaultJvmOpts = ['-Dplay.http.secret.key=yadayada']
 // }
 
-dependencies {
-    play "com.typesafe.play:play-guice_\$scalaVersion:\$playVersion"
-    play "com.typesafe.play:play-logback_\$scalaVersion:\$playVersion"
-    play "com.typesafe.play:filters-helpers_\$scalaVersion:\$playVersion"
+def dependencyFor(String lib, String scalaVersion, String version) {
+    return lib + "_" + scalaVersion + ":" + version
+} 
 
-    playTest "org.scalatestplus.play:scalatestplus-play_\$scalaVersion:3.1.2"
+dependencies {
+
+    playTest dependencyFor("com.typesafe.play:play-guice", scalaVersion, playVersion)
+    playTest dependencyFor("com.typesafe.play:play-logback", scalaVersion, playVersion)
+    playTest dependencyFor("com.typesafe.play:filters-helpers", scalaVersion, playVersion)
+
+    playTest dependencyFor("org.scalatestplus.play:scalatestplus-play", scalaVersion, "3.1.2")
 }
 
 repositories {

--- a/src/main/g8/build.gradle
+++ b/src/main/g8/build.gradle
@@ -57,9 +57,9 @@ def dependencyFor(String lib, String scalaVersion, String version) {
 
 dependencies {
 
-    playTest dependencyFor("com.typesafe.play:play-guice", scalaVersion, playVersion)
-    playTest dependencyFor("com.typesafe.play:play-logback", scalaVersion, playVersion)
-    playTest dependencyFor("com.typesafe.play:filters-helpers", scalaVersion, playVersion)
+    play dependencyFor("com.typesafe.play:play-guice", scalaVersion, playVersion)
+    play dependencyFor("com.typesafe.play:play-logback", scalaVersion, playVersion)
+    play dependencyFor("com.typesafe.play:filters-helpers", scalaVersion, playVersion)
 
     playTest dependencyFor("org.scalatestplus.play:scalatestplus-play", scalaVersion, "3.1.2")
 }


### PR DESCRIPTION
This PR removes the usage of interpolation variables that have been a source of issues when running TemplateControl on a Giter8 template. 

