### PR TITLE
[2.8.x] Pass empty argument list () in routes file

### DIFF
--- a/src/main/g8/conf/routes
+++ b/src/main/g8/conf/routes
@@ -4,7 +4,7 @@
 # ~~~~
 
 # An example controller showing a sample home page
-GET     /                           controllers.HomeController.index
+GET     /                           controllers.HomeController.index()
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
Avoids

```
[warn] ./conf/routes:7:1: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method index,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn] GET     /                           controllers.HomeController.index
```