### PR TITLE
Revert workarounds for unstable 2.9.x branch / sbt 1.8.0-RC1 

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.0-RC1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,1 @@
-lazy val plugins = (project in file(".")).settings(
-  scalaVersion := "2.12.17", // TODO: remove when upgraded to sbt 1.8.0 (maybe even 1.7.2), see https://github.com/sbt/sbt/pull/7021
-)
-
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8" % "0.16.0")

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.0-RC1

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,6 +1,2 @@
-lazy val plugins = (project in file(".")).settings(
-  scalaVersion := "2.12.17", // TODO: remove when upgraded to sbt 1.8.0 (maybe even 1.7.2), see https://github.com/sbt/sbt/pull/7021
-)
-
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "$play_version$")
 addSbtPlugin("org.foundweekends.giter8" % "sbt-giter8-scaffold" % "0.16.0")


### PR DESCRIPTION
Right now the 2.9.x branch fetches the latest Play unstable version.
Should be changed back to stable until final release.

Ref https://github.com/playframework/play-java-seed.g8/pull/114