### PR TITLE
[2.9.x] Update README + Disable withJansi by default in logback conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sbt new playframework/play-scala-seed.g8
 
 ## Scaffolding
 
-Type `g8Scaffold form` from sbt to create the scaffold controller, template and tests needed to process a form.
+Type `g8Scaffold form` from sbt to create the scaffold controller, template and tests needed to process a form. Be aware you then have to add new routes to the `conf/routes` file, otherwise compilation will fail. See the comments in the newly created controller class which routes need to be added.
 
 You can also create your own giter8 seeds and scaffolds based off this one by forking from the <https://github.com/playframework/play-java-seed.g8> or <https://github.com/playframework/play-scala-seed.g8> github projects.
 

--- a/src/main/g8/conf/logback.xml
+++ b/src/main/g8/conf/logback.xml
@@ -19,7 +19,12 @@
   </appender>
 
   <appender name="STDOUT" class="ConsoleAppender">
-    <withJansi>true</withJansi>
+    <!--
+         On Windows, enabling Jansi is recommended to benefit from color code interpretation on DOS command prompts,
+         which otherwise risk being sent ANSI escape sequences that they cannot interpret.
+         See https://logback.qos.ch/manual/layouts.html#coloring
+    -->
+    <!-- <withJansi>true</withJansi> -->
     <encoder class="PatternLayoutEncoder">
       <charset>UTF-8</charset>
       <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{akkaSource}) %msg%n</pattern>


### PR DESCRIPTION
In Play 2.9 logback got upgraded to 1.3+. There is a change in logback 1.3 which can cause an exception:
https://github.com/qos-ch/logback/pull/414
The pull request description, its diff and the [added docs](https://logback.qos.ch/manual/layouts.html#coloring) says it all: Basically now when `withJansi` is set, not only Windows users are effected anymore (like in logback <1.3) but on every plattform the output stream is wrapped by jansi, which will fail if the jansi dependency is not on the classpath. Long long time ago Play added the jansi dependency ([this PR](https://github.com/playframework/playframework/pull/1714), made it into Play 2.3), however was removed shortly afterwards again in in [this PR](https://github.com/playframework/playframework/pull/4023) for Play 2.4. Actually, reading the commit description of [this commit](https://github.com/playframework/playframework/commit/a8a966596aa9de3bd6da286c2ab1b21e126839fd) it seems that sbt automagically adds jansi to the classpath if you use `run`, which seems to be the case [grep'ing through the sbt source code](https://github.com/search?q=repo%3Asbt%2Fsbt%20jansi&type=code) (but I didn't really look deep).

Anyway, when running tests in Play 2.9 with `withJansi` set, following `ClassNotFoundException` appears now (under Linux) (I also tried `Test / fork := false`, because I thought it's some sbt classpath issue, but it didn't help):

```sh
11:18:15,870 |-INFO in ch.qos.logback.core.ConsoleAppender[STDOUT] - Enabling JANSI AnsiPrintStream for the console.
11:18:15,871 |-WARN in ch.qos.logback.core.ConsoleAppender[STDOUT] - Failed to create AnsiPrintStream. Falling back on the default stream. java.lang.ClassNotFoundException: org.fusesource.jansi.AnsiConsole
        at java.lang.ClassNotFoundException: org.fusesource.jansi.AnsiConsole
        at      at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
        at      at sbt.internal.ManagedClassLoader.findClass(ManagedClassLoader.java:102)
        at      at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
        at      at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        at      at ch.qos.logback.core.ConsoleAppender.wrapWithJansi(ConsoleAppender.java:96)
        at      at ch.qos.logback.core.ConsoleAppender.start(ConsoleAppender.java:86)
        at      at ch.qos.logback.core.model.processor.AppenderModelHandler.postHandle(AppenderModelHandler.java:84)
        at      at ch.qos.logback.core.model.processor.DefaultProcessor.secondPhaseTraverse(DefaultProcessor.java:248)
        at      at ch.qos.logback.core.model.processor.DefaultProcessor.secondPhaseTraverse(DefaultProcessor.java:244)
        at      at ch.qos.logback.core.model.processor.DefaultProcessor.traversalLoop(DefaultProcessor.java:90)
        at      at ch.qos.logback.core.model.processor.DefaultProcessor.process(DefaultProcessor.java:106)
        at      at ch.qos.logback.core.joran.GenericXMLConfigurator.processModel(GenericXMLConfigurator.java:199)
        at      at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:165)
        at      at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:122)
        at      at ch.qos.logback.core.joran.GenericXMLConfigurator.doConfigure(GenericXMLConfigurator.java:65)
        at      at ch.qos.logback.classic.util.DefaultJoranConfigurator.configureByResource(DefaultJoranConfigurator.java:53)
        at      at ch.qos.logback.classic.util.DefaultJoranConfigurator.configure(DefaultJoranConfigurator.java:34)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:93)
        at      at ch.qos.logback.classic.util.ContextInitializer.autoConfig(ContextInitializer.java:77)
        at      at ch.qos.logback.classic.spi.LogbackServiceProvider.initializeLoggerContext(LogbackServiceProvider.java:50)
        at      at ch.qos.logback.classic.spi.LogbackServiceProvider.initialize(LogbackServiceProvider.java:41)
        at      at org.slf4j.LoggerFactory.bind(LoggerFactory.java:152)
        at      at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:139)
        at      at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:422)
        at      at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:408)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:357)
        at      at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:383)
        at      at play.api.Logger$.<clinit>(Logger.scala:265)
        at      at play.api.Configuration$.<clinit>(Configuration.scala:168)
        at      at play.api.inject.guice.GuiceApplicationBuilder$.$lessinit$greater$default$2(GuiceApplicationBuilder.scala:29)
        at      at play.api.inject.guice.GuiceApplicationBuilder.<init>(GuiceApplicationBuilder.scala:47)
        at      at org.scalatestplus.play.guice.GuiceFakeApplicationFactory.fakeApplication(GuiceFakeApplicationFactory.scala:32)
        at      at org.scalatestplus.play.guice.GuiceFakeApplicationFactory.fakeApplication$(GuiceFakeApplicationFactory.scala:32)
        at      at controllers.HomeControllerSpec.fakeApplication(HomeControllerSpec.scala:14)
        at      at org.scalatestplus.play.BaseOneAppPerTest.newAppForTest(BaseOneAppPerTest.scala:70)
        at      at org.scalatestplus.play.BaseOneAppPerTest.newAppForTest$(BaseOneAppPerTest.scala:70)
        at      at controllers.HomeControllerSpec.newAppForTest(HomeControllerSpec.scala:14)
        at      at org.scalatestplus.play.BaseOneAppPerTest.withFixture(BaseOneAppPerTest.scala:88)
        at      at org.scalatestplus.play.BaseOneAppPerTest.withFixture$(BaseOneAppPerTest.scala:87)
        at      at controllers.HomeControllerSpec.withFixture(HomeControllerSpec.scala:14)
        at      at org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1(AnyWordSpecLike.scala:1237)
        at      at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1(AnyWordSpecLike.scala:1249)
        at      at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
        at      at org.scalatest.wordspec.AnyWordSpecLike.runTest(AnyWordSpecLike.scala:1249)
        at      at org.scalatest.wordspec.AnyWordSpecLike.runTest$(AnyWordSpecLike.scala:1231)
        at      at org.scalatest.wordspec.AnyWordSpec.runTest(AnyWordSpec.scala:1880)
        at      at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1(AnyWordSpecLike.scala:1308)
        at      at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
        at      at scala.collection.immutable.List.foreach(List.scala:333)
        at      at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
        at      at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:390)
        at      at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:427)
        at      at scala.collection.immutable.List.foreach(List.scala:333)
        at      at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
        at      at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
        at      at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
        at      at org.scalatest.wordspec.AnyWordSpecLike.runTests(AnyWordSpecLike.scala:1308)
        at      at org.scalatest.wordspec.AnyWordSpecLike.runTests$(AnyWordSpecLike.scala:1307)
        at      at org.scalatest.wordspec.AnyWordSpec.runTests(AnyWordSpec.scala:1880)
        at      at org.scalatest.Suite.run(Suite.scala:1114)
        at      at org.scalatest.Suite.run$(Suite.scala:1096)
        at      at org.scalatest.wordspec.AnyWordSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run(AnyWordSpec.scala:1880)
        at      at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1(AnyWordSpecLike.scala:1353)
        at      at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
        at      at org.scalatest.wordspec.AnyWordSpecLike.run(AnyWordSpecLike.scala:1353)
        at      at org.scalatest.wordspec.AnyWordSpecLike.run$(AnyWordSpecLike.scala:1351)
        at      at org.scalatest.wordspec.AnyWordSpec.run(AnyWordSpec.scala:1880)
        at      at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
        at      at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:516)
        at      at sbt.TestRunner.runTest$1(TestFramework.scala:147)
        at      at sbt.TestRunner.run(TestFramework.scala:162)
        at      at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1(TestFramework.scala:330)
        at      at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:290)
        at      at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:330)
        at      at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:330)
        at      at sbt.TestFunction.apply(TestFramework.scala:342)
        at      at sbt.Tests$.processRunnable$1(Tests.scala:474)
        at      at sbt.Tests$.$anonfun$makeSerial$1(Tests.scala:480)
        at      at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
        at      at sbt.std.Transform$$anon$4.work(Transform.scala:68)
        at      at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
        at      at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
        at      at sbt.Execute.work(Execute.scala:291)
        at      at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
        at      at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
        at      at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
        at      at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at      at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at      at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at      at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at      at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at      at java.base/java.lang.Thread.run(Thread.java:829)
```

Given that
* no where else in all Play repos nor in Play the `withJansi` config is set (except the seed projects) and
* assumed most (serious? just joking) devs work on macOS and Linux :eyes: 

I think it's ok to just comment that option out and explain what it is about.
Also I think configuring logback is not the responsibility of Play but the dev.