### PR TITLE
import jakarta instead of javax

### DIFF
--- a/src/main/g8/app/controllers/HomeController.scala
+++ b/src/main/g8/app/controllers/HomeController.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import javax.inject._
+import jakarta.inject._
 import play.api._
 import play.api.mvc._
 

--- a/src/main/scaffolds/form/app/controllers/$model__Camel$Controller.scala
+++ b/src/main/scaffolds/form/app/controllers/$model__Camel$Controller.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import javax.inject._
+import jakarta.inject._
 import play.api.mvc._
 
 import play.api.data._


### PR DESCRIPTION
As stated in the [Play framework documentation](https://www.playframework.com/documentation/3.0.x/Highlights29#Guice-Upgraded-to-Version-6), Play will no longer support `javax.inject` after the next major release.