### PR TITLE
`SingleModule` is deprecated, use `RootModule` instead

### DIFF
--- a/src/main/g8/build.sc
+++ b/src/main/g8/build.sc
@@ -1,7 +1,7 @@
 import mill._
 import \$ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
 
-object $name;format="camel"$ extends PlayModule with SingleModule {
+object $name;format="camel"$ extends RootModule with PlayModule {
     
   def scalaVersion = "$scala_version$"
   def playVersion = "$play_version$"


### PR DESCRIPTION
According to https://github.com/com-lihaoyi/mill/pull/2862, please use RootModule instead of SingleModule.