### PR TITLE
Remove frequency from scala steward conf

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -1,5 +1,3 @@
-pullRequests.frequency = "@monthly"
-
 commits.message = "[3.0.x] ${artifactName} ${nextVersion} (was ${currentVersion})"
 
 pullRequests.grouping = [


### PR DESCRIPTION
I was running `sbt new` and was wondering why sbt still was not upgraded to latest version by scala steward. He visited the last time on Mar 3 - because the config was set to 1 month IMHO it just takes to long to upgrade. Specially for the seed projects.