### PR TITLE
[3.0.x] Make scala steward work again

### DIFF
--- a/.github/scala-steward.conf
+++ b/.github/scala-steward.conf
@@ -4,4 +4,7 @@ pullRequests.grouping = [
   { name = "patches", "title" = "[3.0.x] Patch updates", "filter" = [{"version" = "patch"}] }
 ]
 
-buildRoots = [ ".", "src/main/g8" ]
+# buildRoots does not work because src/main/g8/build.sc is invalid as it was not scaffolded yet.
+# E.g. build.sc contains \$ (backslash dollar) which scala-steward / mill can not handle.
+# As workaround we use the phantomDeps project in build.sbt
+#buildRoots = [ ".", "src/main/g8" ]

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src_managed/
 project/plugins/project/
 .idea
 .bsp
+phantom-deps/

--- a/build.sbt
+++ b/build.sbt
@@ -5,3 +5,19 @@ lazy val root = (project in file(".")).
     },
     scriptedLaunchOpts ++= List("-Xms1024m", "-Xmx1024m", "-XX:ReservedCodeCacheSize=128m", "-Xss2m", "-Dfile.encoding=UTF-8"),
   ).enablePlugins(ScriptedPlugin)
+  .aggregate(phantomDeps)
+
+// https://github.com/playframework/play-java-seed.g8/pull/204
+// ensuring deps are updated inside of templates files
+lazy val phantomDeps = (project in file("phantom-deps"))
+  .disablePlugins(ScriptedPlugin, Giter8Plugin)
+  .settings(
+    publish / skip := true,
+    scalaVersion := "2.13.16", // ! Also update in src/main/g8/[build.sc|build.sbt] !
+    libraryDependencies ++= Seq(
+      "org.playframework.twirl" %% "twirl-compiler" % "2.0.8", // ! Also update in src/main/g8/build.sc !
+      "org.scalatestplus.play" %%"scalatestplus-play" % "7.0.1", // ! Also update in src/main/g8/build.sbt !
+      "org.playframework" %% "play-routes-compiler" % "3.0.7", // ! Also update in src/main/g8/[build.sc|project/plugins.sbt] !
+      "org.foundweekends.giter8" %% "giter8" % "0.17.0", // ! Also update in project/plugins.sbt and src/main/g8/project/plugins.sbt !
+    )
+  )


### PR DESCRIPTION
Since `build.sc` is a g8 template file it contains `\$` (backslash dollar) which scala-steward / mill can not handle.

Workaround is not the nicest one but it should work. Make
It is base on the idea here:
- https://github.com/disneystreaming/smithy4s.g8/pull/43

Error was:
```
2025-06-24 12:11:01,309 ERROR Steward mkurz/play-scala-seed.g8:3.0.x failed
org.scalasteward.core.io.process$ProcessFailedException: 'mill -i -p /home/mkurz/work/scala-steward/testdata/workspace/repos/mkurz/play-scala-seed.g8/src/main/g8/scala-steward.sc show org.scalasteward.mill.plugin.StewardPlugin/extractDeps' exited with code 1.
1 targets failed
generateScriptSources build.sc:2:9 expected ("}" | end-of-input)
import \$ivy.`com.lihaoyi::mill-contrib-playlib:`,  mill.playlib._
        ^

        at org.scalasteward.core.io.process$.$anonfun$slurp$7(process.scala:78)
        at org.scalasteward.core.io.process$.$anonfun$slurp$7$adapted(process.scala:72)
        at flatMap @ org.scalasteward.core.io.process$.$anonfun$slurp$5(process.scala:72)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at modify @ fs2.internal.Scope.$anonfun$open$4(Scope.scala:149)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at uncancelable @ fs2.Compiler$Target.uncancelable(Compiler.scala:165)
        at rethrow$extension @ fs2.Compiler$Target.$anonfun$compile$1(Compiler.scala:157)
        at get @ fs2.internal.Scope.openScope(Scope.scala:278)
        at flatMap @ fs2.Compiler$Target.flatMap(Compiler.scala:163)
        at flatMap @ fs2.Pull$.$anonfun$compile$21(Pull.scala:1214)
```